### PR TITLE
Snapshot name fix

### DIFF
--- a/eve4pve-autosnap
+++ b/eve4pve-autosnap
@@ -306,16 +306,12 @@ function remove_old_snapshots(){
 
     local snapshots;
 
-    #check output
-    if [ $($vm_tecnology listsnapshot $vm_id | awk '{print $1}' | grep '\->' | wc -l) -gt 0 ]; then
-        snapshots=$($vm_tecnology listsnapshot $vm_id | \
-                    awk '{print $2}' | \
-                    grep "$snap_name_prefix" | sort -r);   
-    else
-        snapshots=$($vm_tecnology listsnapshot $vm_id | \
-                    awk '{print $1}' | \
-                    grep "$snap_name_prefix" | sort -r);
-    fi
+    snapshots=$($vm_tecnology listsnapshot $vm_id | \
+                grep "$PROGNAME" | \
+                sed -r 's/[^a]*(.*?)$/\1/' | \
+                awk '{print $1}' | \
+                grep "$snap_name_prefix" | \
+                sort -r );
 
     local -i index=0
     local snap_name=''
@@ -348,9 +344,10 @@ function status(){
             local result;
             result=$($tecnology listsnapshot "$vm" | \
                      grep "$PROGNAME" | \
+		     sed -r 's/[^a]*(.*?)$/\1/' | \
                      sort -r | \
                      awk -v vm="$vm" '{print vm,substr($1,1+length($1)-12),substr($1,5,1+length($1)-12-5)}' | \
-                     awk 'BEGIN {FIELDWIDTHS="4 2 2 2 2 2 2 10"} {printf "%s %s-%s-%s %s:%s:%s %s\n",$1,$2,$3,$4,$5,$6,$7,$8}')
+                     awk 'BEGIN {FIELDWIDTHS="6 14 10"} {printf "%s %s %s\n",$1,$2,$3}')
 
             if [ ! -z "$result" ]; then
                 if [ $print_header -eq 1 ]; then


### PR DESCRIPTION
Fixed the read of existing snapshot names in:
 - remove_old_snapshots
 - status

This fixes:
*) status output

Before on Ceph:
eve4pve-autosnap status
VM   SNAPSHOTS          LABEL
100 190620230005-daily- ::

After:
eve4pve-autosnap status
VM   SNAPSHOTS          LABEL
100 190627160350 daily

testet with: zfs, ceph, local

*) correct auto delete of snapshots on ZFS. (Before snapshots on some ZFS hosts were not deleted)

Output from ZFS on pve host 1:
pve1# qm listsnapshot 310
`-> autodaily190623230006       2019-06-23 23:00:13     eve4pve-autosnap
    `-> autodaily190624230004   2019-06-24 23:00:11     eve4pve-autosnap
        `-> autodaily190625230017 2019-06-25 23:01:10     eve4pve-autosnap

Output from ZFS on pve host 2:
pve2# qm listsnapshot 1902
autodaily190627160118 no-parent            eve4pve-autosnap
autodaily190627174021 autodaily190627173751 eve4pve-autosnap
autodaily190627173751 autodaily190627160118 eve4pve-autosnap

(Standard pve installations, both full updated)