### PR TITLE
Fix storage check to ignore bind mounts in LXC containers (issue #108)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>1.18.0</Version>
+    <Version>1.19.0</Version>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Corsinvest.ProxmoxVE.AutoSnap.Api/Application.cs
+++ b/src/Corsinvest.ProxmoxVE.AutoSnap.Api/Application.cs
@@ -353,12 +353,17 @@ Max % Storage :   {maxPercentageStorage}%");
 
             if (checkStorage && vmConfig.Disks.Any())
             {
-                //verify storage
-                var validStorage = false;
+                //verify storage - check only Proxmox managed storages, ignore bind mounts
+                var validStorage = true;
                 foreach (var item in vmConfig.Disks)
                 {
-                    storagesCheck.TryGetValue($"{vm.Node}/{item.Storage}", out validStorage);
-                    if (!validStorage) { break; }
+                    // Check only if storage exists in storagesCheck (Proxmox managed storage)
+                    // If not found (e.g., bind mount directory), ignore it
+                    if (storagesCheck.TryGetValue($"{vm.Node}/{item.Storage}", out var isValid) && !isValid)
+                    {
+                        validStorage = false;
+                        break;
+                    }
                 }
 
                 if (!validStorage)


### PR DESCRIPTION
## Summary

Fixed bug #108 where LXC containers with bind mount directories were incorrectly skipped during snapshot creation with the message "Skip VM problem storage space out of 100%".

## Problem

After upgrading to Proxmox VE 9, LXC containers configured with bind mount directories (e.g., `mp1: /storage1,mp=/storage1`) were being skipped during snapshot operations. The storage validation logic was checking ALL disk storage entries, including bind mounts, which are not Proxmox-managed storages and therefore not present in the `storagesCheck` dictionary.

When a bind mount directory was encountered:
- `TryGetValue` returned `false` (storage not found)
- `validStorage` was set to `false`
- VM was skipped with "problem storage space" message

## Solution

Modified the storage validation logic to:
- Initialize `validStorage = true` (optimistic approach)
- Check only if storage exists in `storagesCheck` (Proxmox-managed storage)
- Skip validation for storages not found (bind mounts, external directories)
- Set `validStorage = false` only when a Proxmox-managed storage exceeds the space threshold

## Why This Is Correct

Snapshots in Proxmox only capture Proxmox-managed storage volumes (ZFS subvolumes, LVM volumes, etc.). Bind mount directories are external filesystem paths that:
- Are not included in snapshots
- Do not consume space in Proxmox storage pools
- Should not prevent snapshot creation

## Testing

Containers with configurations like:
```
rootfs: local-zfs:subvol-100-disk-0,size=8G
mp0: local-zfs:subvol-100-disk-1,mp=/data,size=10G
mp1: /storage1,mp=/storage1
```

Will now correctly create snapshots, ignoring the `/storage1` bind mount during storage space validation.

Fixes #108