### PR TITLE
Add --max-parallel option and code improvements for v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-04-14
+
+### Added
+- `--max-parallel` option for `snap` command — snapshot multiple VMs at the same time to significantly reduce total run time on large clusters (default: 1, sequential); output remains grouped per VM even when running in parallel
+
 ## [2.0.1] - 2026-04-09
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.0.1</Version>
+    <Version>2.1.0</Version>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.11" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.11" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.13" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.13" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -54,13 +54,14 @@ All binaries on the [Releases page](https://github.com/Corsinvest/cv4pve-autosna
 - **API-based** — no root or SSH access required
 - **Cluster-aware** — works across all nodes automatically
 - **High availability** — multiple host support for automatic failover
-- **Flexible targeting** — select VMs by ID, name, pool, tag, node or pattern
+- **Flexible targeting** — select VMs by ID, name, pool, tag, node or pattern ([see VM/CT Selection](#vmct-selection))
 - **Retention policies** — configurable keep count per label
-- **Multiple schedules** — use labels (hourly, daily, weekly, monthly)
+- **Multiple schedules** — use labels (hourly, daily, weekly, monthly) ([see Scheduling](#scheduling-with-cron))
 - **Memory state** — optional RAM state preservation with `--state`
-- **Hook scripts** — custom automation before/after each phase
+- **Hook scripts** — custom automation before/after each phase ([see Hook Scripts](#hook-scripts))
 - **Storage monitoring** — skip snapshot if storage above threshold
 - **QEMU Guest Agent** — warns if not enabled on a VM; recommended for consistent snapshots ([setup guide](docs/snapshot-consistency.md))
+- **Parallel execution** — snapshot multiple VMs concurrently with `--max-parallel` ([see Performance](#performance))
 - **API token** support (Proxmox VE 6.2+)
 - **Dry-run** mode — test without making changes
 
@@ -97,9 +98,32 @@ cv4pve-autosnap --host=pve.local --api-token=user@realm!token=uuid --vmid=100 st
 # Dry-run (no changes)
 cv4pve-autosnap --host=pve.local --api-token=user@realm!token=uuid --vmid=100 --dry-run snap --label=daily --keep=7
 
+# Parallel snapshots (up to 5 VMs at once)
+cv4pve-autosnap --host=pve.local --api-token=user@realm!token=uuid --vmid=@all snap --label=daily --keep=7 --max-parallel 5
+
 # Parameter file (recommended for complex setups)
 cv4pve-autosnap @/etc/cv4pve/production.conf snap --label=daily --keep=14
 ```
+
+---
+
+## Performance
+
+By default snapshots are processed **sequentially** (`--max-parallel 1`). On large clusters with VMs spread across multiple nodes or using ZFS/Ceph storage, parallel execution significantly reduces total run time.
+
+```bash
+# Run up to 5 snapshots in parallel
+cv4pve-autosnap --host=pve.local --api-token=token --vmid=@all snap --label=daily --keep=7 --max-parallel 5
+```
+
+| Setting | Effect | Default |
+|---------|--------|---------|
+| `--max-parallel 1` | Sequential — one VM at a time | default |
+| `--max-parallel N` | Up to N VMs snapshotted concurrently | — |
+
+> **Tip:** values between 3 and 10 are a reasonable range. ZFS and Ceph handle parallel snapshots very well.
+>
+> **Warning:** if multiple VMs share the same storage backend, parallel snapshots compete for the same I/O — this can slow down or destabilize the storage. On shared or slow storage (NFS, iSCSI, LVM) keep `--max-parallel` low (2–3) or leave it at the default of 1. On distributed storage (Ceph/RBD) or per-VM storage (ZFS datasets) higher values are safe.
 
 ---
 

--- a/src/Corsinvest.ProxmoxVE.AutoSnap.Api/AutoSnapEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.AutoSnap.Api/AutoSnapEngine.cs
@@ -14,21 +14,27 @@ using Corsinvest.ProxmoxVE.Api.Shared.Models.Vm;
 using Corsinvest.ProxmoxVE.Api.Shared.Utils;
 using Microsoft.Extensions.Logging;
 
+
 namespace Corsinvest.ProxmoxVE.AutoSnap.Api;
 
 /// <summary>
 /// AutoSnap engine.
 /// </summary>
-/// <remarks>
-/// Constructor command
-/// </remarks>
-/// <param name="client"></param>
-/// <param name="loggerFactory"></param>
-/// <param name="out"></param>
-/// <param name="dryRun"></param>
-public class AutoSnapEngine(PveClient client, ILoggerFactory loggerFactory, TextWriter @out, bool dryRun)
+public partial class AutoSnapEngine(PveClient client, ILoggerFactory loggerFactory, TextWriter @out, bool dryRun)
 {
     private readonly ILogger<AutoSnapEngine> _logger = loggerFactory.CreateLogger<AutoSnapEngine>();
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Phase: {Phase}")]
+    private partial void LogPhase(string phase);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Unexpected error")]
+    private partial void LogUnexpectedError(Exception ex);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Snap remove: problem in remove")]
+    private partial void LogSnapRemoveProblem();
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Snap exit: {Status}")]
+    private partial void LogSnapExit(bool status);
 
     /// <summary>
     /// Permissions request
@@ -36,7 +42,7 @@ public class AutoSnapEngine(PveClient client, ILoggerFactory loggerFactory, Text
     /// <value></value>
     public IEnumerable<string> Permissions { get; } = ["VM.Audit", "VM.Snapshot", "Datastore.Audit", "Pool.Allocate"];
 
-    private static readonly string Prefix = "auto";
+    private const string Prefix = "auto";
 
     /// <summary>
     /// Default time stamp format
@@ -47,11 +53,6 @@ public class AutoSnapEngine(PveClient client, ILoggerFactory loggerFactory, Text
     /// Application name
     /// </summary>
     public static readonly string Name = "cv4pve-autosnap";
-
-    /// <summary>
-    /// Old application name
-    /// </summary>
-    private static readonly string OldName = "eve4pve-autosnap";
 
     private static string GetTimestampFormat(string timestampFormat)
         => string.IsNullOrWhiteSpace(timestampFormat)
@@ -68,7 +69,7 @@ public class AutoSnapEngine(PveClient client, ILoggerFactory loggerFactory, Text
     {
         var tmsLen = GetTimestampFormat(timestampFormat).Length;
         var prfLen = Prefix.Length;
-        return tmsLen + prfLen < name.Length ? name[prfLen..^tmsLen] : string.Empty;
+        return tmsLen + prfLen < name.Length ? name[prfLen..^tmsLen] : "";
     }
 
     /// <summary>
@@ -95,13 +96,6 @@ public class AutoSnapEngine(PveClient client, ILoggerFactory loggerFactory, Text
     };
 
     /// <summary>
-    /// Phase string to enum
-    /// </summary>
-    /// <param name="phase"></param>
-    /// <returns></returns>
-    public static HookPhase PhaseStrToEnum(string phase) => Phases[phase];
-
-    /// <summary>
     /// Phase enum to string
     /// </summary>
     /// <param name="phase"></param>
@@ -110,14 +104,14 @@ public class AutoSnapEngine(PveClient client, ILoggerFactory loggerFactory, Text
 
     private async Task CallPhaseEventAsync(PhaseEventArgs args)
     {
-        _logger.LogDebug("Phase: {phase}", PhaseEnumToStr(args.Phase));
+        LogPhase(PhaseEnumToStr(args.Phase));
 
         if (PhaseEvent is null) { return; }
 
         foreach (var handler in PhaseEvent.GetInvocationList().Cast<Func<PhaseEventArgs, Task>>())
         {
             try { await handler(args); }
-            catch (Exception ex) { _logger.LogError(ex, ex.Message); }
+            catch (Exception ex) { LogUnexpectedError(ex); }
         }
     }
 
@@ -130,7 +124,9 @@ public class AutoSnapEngine(PveClient client, ILoggerFactory loggerFactory, Text
     /// <param name="vmIdsOrNames"></param>
     /// <param name="label"></param>
     /// <param name="timestampFormat"></param>
-    public async Task<IReadOnlyDictionary<IClusterResourceVm, IEnumerable<VmSnapshot>>> StatusAsync(string vmIdsOrNames, string label, string timestampFormat)
+    public async Task<IReadOnlyDictionary<IClusterResourceVm, IEnumerable<VmSnapshot>>> StatusAsync(string vmIdsOrNames,
+                                                                                                    string label,
+                                                                                                    string timestampFormat)
     {
         timestampFormat = GetTimestampFormat(timestampFormat);
 
@@ -146,15 +142,14 @@ public class AutoSnapEngine(PveClient client, ILoggerFactory loggerFactory, Text
     }
 
     private static IEnumerable<VmSnapshot> FilterApp(IEnumerable<VmSnapshot> snapshots)
-        => snapshots.Where(a => (a.Description + string.Empty).Replace("\n", string.Empty) == Name
-                                || (a.Description + string.Empty).Replace("\n", string.Empty) == OldName);
+        => snapshots.Where(a => (a.Description + "").Replace("\n", "") == Name);
 
     private static string GetPrefix(string label) => Prefix + label;
 
     private static IEnumerable<VmSnapshot> FilterLabel(IEnumerable<VmSnapshot> snapshots, string label, string timestampFormat)
     {
         var lenTms = GetTimestampFormat(timestampFormat).Length;
-        return FilterApp(snapshots.Where(a => (a.Name.Length - lenTms) > 0 && a.Name[..^lenTms] == GetPrefix(label)));
+        return FilterApp(snapshots.Where(a => (a.Name.Length > lenTms) && a.Name[..^lenTms] == GetPrefix(label)));
     }
 
     /// <summary>
@@ -168,6 +163,7 @@ public class AutoSnapEngine(PveClient client, ILoggerFactory loggerFactory, Text
     /// <param name="timestampFormat"></param>
     /// <param name="maxPercentageStorage"></param>
     /// <param name="onlyRuns"></param>
+    /// <param name="maxParallel"></param>
     /// <returns></returns>
     public async Task<ResultSnap> SnapAsync(string vmIdsOrNames,
                                             string label,
@@ -176,7 +172,8 @@ public class AutoSnapEngine(PveClient client, ILoggerFactory loggerFactory, Text
                                             long timeout,
                                             string timestampFormat,
                                             int maxPercentageStorage,
-                                            bool onlyRuns)
+                                            bool onlyRuns,
+                                            int maxParallel)
     {
         timestampFormat = GetTimestampFormat(timestampFormat);
         var pveFullVersion = (await client.Version.Version()).ToData().version as string;
@@ -202,212 +199,145 @@ Max % Storage :   {maxPercentageStorage}%");
 
         await CallPhaseEventAsync(new(HookPhase.SnapJobStart, null, label, keep, null, state, 0, true));
 
-        var storagesCheck = new Dictionary<string, bool>();
-        var storagesPrint = new List<object[]>();
-
         var vms = await GetVmsAsync(vmIdsOrNames);
         if (!vms.Any())
         {
             @out.WriteLine($"----- VMs with '{vmIdsOrNames}' NOT FOUND -----");
-            @out.WriteLine($"----- POSSIBLE PROBLEM PERMISSION 'VM.Audit' -----");
+            @out.WriteLine("----- POSSIBLE PROBLEM PERMISSION 'VM.Audit' -----");
         }
 
         var nodes = vms.Select(a => a.Node).Distinct().ToList();
-
         var checkStorage = pveVersion >= 6;
+        var storagesCheck = await CheckStoragesAsync(nodes, maxPercentageStorage, checkStorage, pveFullVersion!);
 
-        if (checkStorage)
+        var semaphore = new SemaphoreSlim(maxParallel);
+
+        var tasks = vms.Select(async vm =>
         {
-            var contentAllowed = new[] { "images", "rootdir" };
-
-            var storages = (await client.GetStoragesAsync())
-                                .Where(a => !a.IsUnknown && nodes.Contains(a.Node))
-                                .ToList();
-
-            if (storages.Exists(a => string.IsNullOrWhiteSpace(a.Content)))
+            await semaphore.WaitAsync();
+            var vmOut = new StringWriter();
+            try
             {
-                //content not exists
-                //found in nodes/storages
-                foreach (var node in nodes)
-                {
-                    var nodeStorages = await client.Nodes[node].Storage.GetAsync(string.Join(",", contentAllowed));
+                vmOut.WriteLine($"----- VM {vm.VmId} {vm.Type} {vm.Status} -----");
 
-                    foreach (var storage in storages.Where(a => a.Node == node))
+                var resultSnapVm = new ResultSnapVm { VmId = vm.VmId };
+                lock (ret.Vms) { ret.Vms.Add(resultSnapVm); }
+
+                if (!vm.IsRunning && onlyRuns)
+                {
+                    vmOut.WriteLine("Skip VM '--only-running' parameter used!");
+                    return;
+                }
+
+                //exclude template
+                if (vm.IsTemplate)
+                {
+                    vmOut.WriteLine("Skip VM is template");
+                    return;
+                }
+
+                var vmConfig = await client.GetVmConfigAsync(vm.Node, vm.VmType, vm.VmId);
+                resultSnapVm.Start();
+
+                //check agent enabled
+                if (vm.VmType == VmType.Qemu && !((VmConfigQemu)vmConfig).AgentEnabled)
+                {
+                    vmOut.WriteLine($"VM {vm.VmId} consider enabling QEMU agent see https://pve.proxmox.com/wiki/Qemu-guest-agent");
+                }
+
+                if (checkStorage && vmConfig.Disks.Any())
+                {
+                    var validStorage = true;
+                    foreach (var item in vmConfig.Disks)
                     {
-                        storage.Content = nodeStorages.FirstOrDefault(a => a.Storage == storage.Storage
-                                                                            && a.Type == storage.PluginType)
-                                                      ?.Content ?? string.Empty;
+                        if (storagesCheck.TryGetValue($"{vm.Node}/{item.Storage}", out var isValid) && !isValid)
+                        {
+                            validStorage = false;
+                            break;
+                        }
                     }
-                }
-            }
 
-            storages = storages.Where(a => a.Content.Split(',')
-                               .Any(a => contentAllowed.Contains(a)))
-                               .OrderBy(a => a.Node)
-                               .ThenBy(a => a.Storage)
-                               .ToList();
-
-            if (storages.Count == 0) { @out.WriteLine($"----- POSSIBLE PROBLEM PERMISSION 'Datastore.Audit' -----"); }
-
-            //check storage capacity
-            foreach (var storage in storages)
-            {
-                var valid = !(storage.DiskUsage == 0
-                                || storage.DiskSize == 0
-                                || storage.DiskUsagePercentage > maxPercentageStorage);
-
-                var key = $"{storage.Node}/{storage.Storage}";
-                storagesPrint.Add(item:
-                [
-                    key,
-                    storage.PluginType,
-                    valid? "Ok": "Ko",
-                    Math.Round(storage.DiskUsagePercentage * 100, 1),
-                    FormatHelper.FromBytes(storage.DiskSize),
-                    FormatHelper.FromBytes(storage.DiskUsage),
-                ]);
-
-                storagesCheck.Add(key, valid);
-            }
-
-            if (storagesPrint.Count != 0)
-            {
-                var size = new[] { 25, 10, 10, 10, 12, 12 };
-
-                string FormatLine(object[] values)
-                {
-                    var ret = new StringBuilder();
-                    for (int i = 0; i < size.Length; i++) { ret.Append((values[i] + string.Empty).PadLeft(size[i])); }
-                    return ret.ToString();
-                }
-
-                @out.WriteLine(FormatLine(["Storage", "Type", "Valid", "Used % ", "Disk Size", "Disk Usage"]));
-                foreach (var item in storagesPrint) { @out.WriteLine(FormatLine(item)); }
-            }
-        }
-        else
-        {
-            @out.WriteLine($"The Proxmox VE version {pveFullVersion} does not verify the storage % usage!");
-        }
-
-        foreach (var vm in vms)
-        {
-            @out.WriteLine($"----- VM {vm.VmId} {vm.Type} {vm.Status} -----");
-
-            if (!vm.IsRunning && onlyRuns)
-            {
-                @out.WriteLine("Skip VM '--only-running' parameter used!");
-                continue;
-            }
-
-            //exclude template
-            if (vm.IsTemplate)
-            {
-                @out.WriteLine("Skip VM is template");
-                continue;
-            }
-
-            VmConfig vmConfig = vm.VmType switch
-            {
-                VmType.Qemu => await client.Nodes[vm.Node].Qemu[vm.VmId].Config.GetAsync(),
-                VmType.Lxc => await client.Nodes[vm.Node].Lxc[vm.VmId].Config.GetAsync(),
-                _ => throw new InvalidEnumArgumentException(),
-            };
-
-            var resultSnapVm = new ResultSnapVm
-            {
-                VmId = vm.VmId
-            };
-            ret.Vms.Add(resultSnapVm);
-            resultSnapVm.Start();
-
-            //check agent enabled
-            if (vm.VmType == VmType.Qemu && !((VmConfigQemu)vmConfig).AgentEnabled)
-            {
-                @out.WriteLine($"VM {vm.VmId} consider enabling QEMU agent see https://pve.proxmox.com/wiki/Qemu-guest-agent");
-            }
-
-            if (checkStorage && vmConfig.Disks.Any())
-            {
-                //verify storage - check only Proxmox managed storages, ignore bind mounts
-                var validStorage = true;
-                foreach (var item in vmConfig.Disks)
-                {
-                    // Check only if storage exists in storagesCheck (Proxmox managed storage)
-                    // If not found (e.g., bind mount directory), ignore it
-                    if (storagesCheck.TryGetValue($"{vm.Node}/{item.Storage}", out var isValid) && !isValid)
+                    if (!validStorage)
                     {
-                        validStorage = false;
-                        break;
+                        vmOut.WriteLine($"Skip VM problem storage space out of {maxPercentageStorage}%");
+                        resultSnapVm.Stop();
+                        return;
                     }
                 }
 
-                if (!validStorage)
+                //create snapshot
+                await CallPhaseEventAsync(new(HookPhase.SnapCreatePre, vm, label, keep, snapName, state, 0, true));
+
+                vmOut.WriteLine($"Create snapshot: {snapName}");
+
+                var inError = false;
+                if (!dryRun)
                 {
-                    @out.WriteLine($"Skip VM problem storage space out of {maxPercentageStorage}%");
+                    try
+                    {
+                        var result = await SnapshotHelper.CreateSnapshotAsync(client,
+                                                                              vm.Node,
+                                                                              vm.VmType,
+                                                                              vm.VmId,
+                                                                              snapName,
+                                                                              Name,
+                                                                              state,
+                                                                              timeout);
+                        inError = await CheckResultAsync(result);
+                    }
+                    catch (Exception ex)
+                    {
+                        inError = true;
+                        LogUnexpectedError(ex);
+                        vmOut.WriteLine(ex.Message);
+                    }
+                }
+
+                if (inError)
+                {
                     resultSnapVm.Stop();
-                    continue;
+                    await CallPhaseEventAsync(new(HookPhase.SnapCreateAbort, vm, label, keep, snapName, state, resultSnapVm.Elapsed.TotalSeconds, false));
+                    return;
                 }
-            }
 
-            //create snapshot
-            await CallPhaseEventAsync(new(HookPhase.SnapCreatePre, vm, label, keep, snapName, state, 0, true));
-
-            @out.WriteLine($"Create snapshot: {snapName}");
-
-            var inError = false;
-            if (!dryRun)
-            {
-                try
+                //remove old snapshot
+                if (!await SnapshotsRemoveAsync(vm, label, keep, timeout, timestampFormat))
                 {
-                    var result = await SnapshotHelper.CreateSnapshotAsync(client,
-                                                                          vm.Node,
-                                                                          vm.VmType,
-                                                                          vm.VmId,
-                                                                          snapName,
-                                                                          Name,
-                                                                          state,
-                                                                          timeout);
-
-                    inError = await CheckResultAsync(result);
+                    resultSnapVm.Stop();
+                    return;
                 }
-                catch (Exception ex)
-                {
-                    inError = true;
-                    _logger.LogError(ex, ex.Message);
-                    @out.WriteLine(ex.Message);
-                }
-            }
 
-            if (inError)
-            {
                 resultSnapVm.Stop();
-                await CallPhaseEventAsync(new(HookPhase.SnapCreateAbort, vm, label, keep, snapName, state, resultSnapVm.Elapsed.TotalSeconds, false));
-                continue;
-            }
+                resultSnapVm.Status = true;
 
-            //remove old snapshot
-            if (!await SnapshotsRemoveAsync(vm, label, keep, timeout, timestampFormat))
+                await CallPhaseEventAsync(new(HookPhase.SnapCreatePost, vm, label, keep, snapName, state, resultSnapVm.Elapsed.TotalSeconds, resultSnapVm.Status));
+
+                vmOut.WriteLine($"VM execution {resultSnapVm.Elapsed}");
+            }
+            finally
             {
-                resultSnapVm.Stop();
-                continue;
+                lock (@out) { @out.Write(vmOut); }
+                semaphore.Release();
             }
+        });
 
-            resultSnapVm.Stop();
-            resultSnapVm.Status = true;
+        await Task.WhenAll(tasks);
 
-            await CallPhaseEventAsync(new(HookPhase.SnapCreatePost, vm, label, keep, snapName, state, resultSnapVm.Elapsed.TotalSeconds, resultSnapVm.Status));
-
-            @out.WriteLine($"VM execution {resultSnapVm.Elapsed}");
-        }
 
         ret.Stop();
 
-        await CallPhaseEventAsync(new(HookPhase.SnapJobEnd, null, label, keep, null, state, ret.Elapsed.TotalSeconds, ret.Status));
+        await CallPhaseEventAsync(new(HookPhase.SnapJobEnd,
+                                      null,
+                                      label,
+                                      keep,
+                                      null,
+                                      state,
+                                      ret.Elapsed.TotalSeconds,
+                                      ret.Status));
 
         @out.WriteLine($"Total execution {ret.Elapsed}");
 
-        _logger.LogDebug($"Snap Exit: {ret.Status}");
+        LogSnapExit(ret.Status);
 
         return ret;
     }
@@ -429,8 +359,7 @@ Max % Storage :   {maxPercentageStorage}%");
 VMs:              {vmIdsOrNames}
 Label:            {label}
 Keep:             {keep}
-Timeout:          {Math.Round(timeout / 1000.0, 1)} sec.
-Timestamp format: {timestampFormat}");
+Timeout:          {Math.Round(timeout / 1000.0, 1)} sec.Timestamp format: {timestampFormat}");
 
         var watch = new Stopwatch();
         watch.Start();
@@ -452,7 +381,14 @@ Timestamp format: {timestampFormat}");
         }
 
         watch.Stop();
-        await CallPhaseEventAsync(new(HookPhase.CleanJobEnd, null, label, keep, null, false, watch.Elapsed.TotalSeconds, ret));
+        await CallPhaseEventAsync(new(HookPhase.CleanJobEnd,
+                                      null,
+                                      label,
+                                      keep,
+                                      null,
+                                      false,
+                                      watch.Elapsed.TotalSeconds,
+                                      ret));
 
         return ret;
     }
@@ -465,7 +401,7 @@ Timestamp format: {timestampFormat}");
         //check error in task
         if (await client.TaskIsRunningAsync(result.ToData<string>()))
         {
-            @out.WriteLine($"Error task in run... increase the timeout!");
+            @out.WriteLine("Error task in run... increase the timeout!");
             inError = true;
         }
         else
@@ -514,7 +450,7 @@ Timestamp format: {timestampFormat}");
                 catch (Exception ex)
                 {
                     inError = true;
-                    _logger.LogError(ex, ex.Message);
+                    LogUnexpectedError(ex);
                     @out.WriteLine(ex.Message);
                 }
             }
@@ -522,15 +458,104 @@ Timestamp format: {timestampFormat}");
             watch.Stop();
             if (inError)
             {
-                _logger.LogWarning("Snap remove: problem in remove");
+                LogSnapRemoveProblem();
 
-                await CallPhaseEventAsync(new(HookPhase.SnapRemoveAbort, vm, label, keep, snapshot.Name, false, watch.Elapsed.TotalSeconds, false));
+                await CallPhaseEventAsync(new(HookPhase.SnapRemoveAbort,
+                                              vm,
+                                              label,
+                                              keep,
+                                              snapshot.Name,
+                                              false,
+                                              watch.Elapsed.TotalSeconds,
+                                              false));
                 return false;
             }
 
-            await CallPhaseEventAsync(new(HookPhase.SnapRemovePost, vm, label, keep, snapshot.Name, false, watch.Elapsed.TotalSeconds, true));
+            await CallPhaseEventAsync(new(HookPhase.SnapRemovePost,
+                                          vm,
+                                          label,
+                                          keep,
+                                          snapshot.Name,
+                                          false,
+                                          watch.Elapsed.TotalSeconds,
+                                          true));
         }
 
         return true;
+    }
+
+    private async Task<Dictionary<string, bool>> CheckStoragesAsync(List<string> nodes,
+                                                                    int maxPercentageStorage,
+                                                                    bool checkStorage,
+                                                                    string pveFullVersion)
+    {
+        var storagesCheck = new Dictionary<string, bool>();
+
+        if (!checkStorage)
+        {
+            @out.WriteLine($"The Proxmox VE version {pveFullVersion} does not verify the storage % usage!");
+            return storagesCheck;
+        }
+
+        var contentAllowed = new[] { "images", "rootdir" };
+
+        var storages = (await client.GetStoragesAsync())
+                            .Where(a => !a.IsUnknown && nodes.Contains(a.Node))
+                            .ToList();
+
+        if (storages.Exists(a => string.IsNullOrWhiteSpace(a.Content)))
+        {
+            foreach (var node in nodes)
+            {
+                var nodeStorages = await client.Nodes[node].Storage.GetAsync(string.Join(",", contentAllowed));
+                foreach (var storage in storages.Where(a => a.Node == node))
+                {
+                    storage.Content = nodeStorages.FirstOrDefault(a => a.Storage == storage.Storage
+                                                                        && a.Type == storage.PluginType)
+                                                  ?.Content ?? "";
+                }
+            }
+        }
+
+        storages = [.. storages.Where(a => a.Content.Split(',').Any(c => contentAllowed.Contains(c)))
+                                .OrderBy(a => a.Node)
+                                .ThenBy(a => a.Storage)];
+
+        if (storages.Count == 0) { @out.WriteLine("----- POSSIBLE PROBLEM PERMISSION 'Datastore.Audit' -----"); }
+
+        var storagesPrint = new List<object[]>();
+        foreach (var storage in storages)
+        {
+            var valid = !(storage.DiskUsage == 0
+                            || storage.DiskSize == 0
+                            || storage.DiskUsagePercentage > maxPercentageStorage);
+
+            var key = $"{storage.Node}/{storage.Storage}";
+            storagesPrint.Add([key,
+                               storage.PluginType,
+                               valid ? "Ok" : "Ko",
+                               Math.Round(storage.DiskUsagePercentage * 100, 1),
+                               FormatHelper.FromBytes(storage.DiskSize),
+                               FormatHelper.FromBytes(storage.DiskUsage)]);
+
+            storagesCheck.Add(key, valid);
+        }
+
+        if (storagesPrint.Count != 0)
+        {
+            var size = new[] { 25, 10, 10, 10, 12, 12 };
+
+            string FormatLine(object[] values)
+            {
+                var ret = new StringBuilder();
+                for (int i = 0; i < size.Length; i++) { ret.Append((values[i] + "").PadLeft(size[i])); }
+                return ret.ToString();
+            }
+
+            @out.WriteLine(FormatLine(["Storage", "Type", "Valid", "Used % ", "Disk Size", "Disk Usage"]));
+            foreach (var item in storagesPrint) { @out.WriteLine(FormatLine(item)); }
+        }
+
+        return storagesCheck;
     }
 }

--- a/src/Corsinvest.ProxmoxVE.AutoSnap.Api/PhaseEventArgs.cs
+++ b/src/Corsinvest.ProxmoxVE.AutoSnap.Api/PhaseEventArgs.cs
@@ -34,19 +34,18 @@ public record PhaseEventArgs(HookPhase Phase,
     /// <summary>
     /// Environments
     /// </summary>
-    /// <value></value>
     public IReadOnlyDictionary<string, string> Environments
         => new Dictionary<string, string>
         {
             ["CV4PVE_AUTOSNAP_PHASE"] = AutoSnapEngine.PhaseEnumToStr(Phase),
-            ["CV4PVE_AUTOSNAP_VMID"] = Vm?.VmId + string.Empty,
-            ["CV4PVE_AUTOSNAP_VMNAME"] = Vm?.Name ?? string.Empty,
-            ["CV4PVE_AUTOSNAP_VMTYPE"] = Vm?.Type + string.Empty,
+            ["CV4PVE_AUTOSNAP_VMID"] = Vm?.VmId + "",
+            ["CV4PVE_AUTOSNAP_VMNAME"] = Vm?.Name ?? "",
+            ["CV4PVE_AUTOSNAP_VMTYPE"] = Vm?.Type + "",
             ["CV4PVE_AUTOSNAP_LABEL"] = Label,
-            ["CV4PVE_AUTOSNAP_KEEP"] = Keep + string.Empty,
-            ["CV4PVE_AUTOSNAP_SNAP_NAME"] = SnapName ?? string.Empty,
+            ["CV4PVE_AUTOSNAP_KEEP"] = Keep + "",
+            ["CV4PVE_AUTOSNAP_SNAP_NAME"] = SnapName ?? "",
             ["CV4PVE_AUTOSNAP_VMSTATE"] = VmState ? "1" : "0",
-            ["CV4PVE_AUTOSNAP_DURATION"] = (Duration + string.Empty).Replace(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator, "."),
+            ["CV4PVE_AUTOSNAP_DURATION"] = (Duration + "").Replace(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator, "."),
             ["CV4PVE_AUTOSNAP_STATE"] = Status ? "1" : "0",
         };
 }

--- a/src/Corsinvest.ProxmoxVE.AutoSnap.Api/ResultSnap.cs
+++ b/src/Corsinvest.ProxmoxVE.AutoSnap.Api/ResultSnap.cs
@@ -13,20 +13,15 @@ public class ResultSnap : ResultBaseSnap
     /// <summary>
     /// Vms
     /// </summary>
-    public List<ResultSnapVm> Vms { get; } = new List<ResultSnapVm>();
+    public List<ResultSnapVm> Vms { get; } = [];
 
     /// <summary>
     /// Status
     /// </summary>
-    /// <value></value>
-    public override bool Status
-    {
-        get => !Vms.Any(a => !a.Status);
-        internal set { }
-    }
+    public override bool Status => Vms.All(a => a.Status);
 
     /// <summary>
     /// Name of the snapshot
     /// </summary>
-    public string SnapName { get; internal set; } = default!;
+    public string SnapName { get; internal set; } = "";
 }

--- a/src/Corsinvest.ProxmoxVE.AutoSnap/Commands.cs
+++ b/src/Corsinvest.ProxmoxVE.AutoSnap/Commands.cs
@@ -36,14 +36,18 @@ public class Commands
         var optTimeout = command.TimeoutOption();
         optTimeout.DefaultValueFactory = (_) => 30L;
 
-        var optTimestampFormat = command.AddOption<string>("--timestamp-format", $"Specify different timestamp format");
+        var optTimestampFormat = command.AddOption<string>("--timestamp-format", "Specify different timestamp format");
         optTimestampFormat.DefaultValueFactory = (_) => AutoSnapEngine.DefaultTimestampFormat;
 
         var optMaxPercentageStorage = command.AddOption<int>("--max-perc-storage", "Max percentage storage")
                                              .AddValidatorRange(1, 100);
         optMaxPercentageStorage.DefaultValueFactory = (_) => 95;
 
-        Snap(command, optVmIds, optTimeout, optTimestampFormat, optMaxPercentageStorage);
+        var optMaxParallel = command.AddOption<int>("--max-parallel", "Max number of parallel snapshots")
+                                    .AddValidatorRange(1, 50);
+        optMaxParallel.DefaultValueFactory = (_) => 1;
+
+        Snap(command, optVmIds, optTimeout, optTimestampFormat, optMaxPercentageStorage, optMaxParallel);
         Clean(command, optVmIds, optTimeout, optTimestampFormat);
         Status(command, optVmIds, optTimestampFormat);
     }
@@ -110,8 +114,8 @@ public class Commands
                                                                    a.Date.ToString("yy/MM/dd HH:mm:ss"),
                                                                    a.Parent,
                                                                    a.Name,
-                                                                   (a.Description + string.Empty).Replace("\n", string.Empty),
-                                                                   a.VmStatus ? "X" : string.Empty }));
+                                                                   (a.Description + "").Replace("\n", ""),
+                                                                   a.VmStatus ? "X" : "" }));
                 }
 
                 _out.Write(TableGenerator.To(["NODE", "VM", "TIME", "PARENT", "NAME", "DESCRIPTION", "VM STATUS"],
@@ -149,7 +153,8 @@ public class Commands
                       Option<string> optVmIds,
                       Option<long> optTimeout,
                       Option<string> optTimestampFormat,
-                      Option<int> optMaxPercentageStorage)
+                      Option<int> optMaxPercentageStorage,
+                      Option<int> optMaxParallel)
     {
         var cmd = command.AddCommand("snap", "Will snap one time");
 
@@ -172,7 +177,8 @@ public class Commands
                                            parseResult.GetValue(optTimeout) * 1000,
                                            parseResult.GetValue(optTimestampFormat)!,
                                            parseResult.GetValue(optMaxPercentageStorage),
-                                           parseResult.GetValue(optOnlyRunning));
+                                           parseResult.GetValue(optOnlyRunning),
+                                           parseResult.GetValue(optMaxParallel));
 
             return snap.Status ? 0 : 1;
         });

--- a/src/Corsinvest.ProxmoxVE.AutoSnap/Program.cs
+++ b/src/Corsinvest.ProxmoxVE.AutoSnap/Program.cs
@@ -5,10 +5,9 @@
 
 using Corsinvest.ProxmoxVE.Api.Console.Helpers;
 using Corsinvest.ProxmoxVE.AutoSnap;
-using Corsinvest.ProxmoxVE.AutoSnap.Api;
 using Microsoft.Extensions.Logging;
 
-var app = ConsoleHelper.CreateApp(AutoSnapEngine.Name, "Automatic snapshot VM/CT with retention");
+var app = ConsoleHelper.CreateApp("Automatic snapshot VM/CT with retention");
 var loggerFactory = ConsoleHelper.CreateLoggerFactory<Program>(app.GetLogLevelFromDebug());
 
 _ = new Commands(app, loggerFactory);


### PR DESCRIPTION
## Summary

- Add `--max-parallel` option to `snap` command — snapshot multiple VMs concurrently to reduce total run time on large clusters (default: 1, sequential, backward-compatible)
- Output is buffered per VM and flushed atomically — no interleaved lines even with parallel execution
- Internal code improvements: extracted `CheckStoragesAsync`, added `[LoggerMessage]` source generator, fixed `ResultSnap` properties

## Test plan

- [ ] Run `snap` with `--max-parallel 1` — verify identical behavior to previous version
- [ ] Run `snap` with `--max-parallel 2` — verify output is grouped per VM, no interleaved lines
- [ ] Verify total execution time is reduced with `--max-parallel > 1` on multiple VMs
- [ ] Verify hook scripts still receive correct environment variables