### PR TITLE
Fix exit code 1 when skipping template or non-running VMs (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-04-20
+
+### Fixed
+- `snap` command no longer returns exit code 1 when the target set includes template VMs or skipped VMs via `--only-running` ([#119](https://github.com/Corsinvest/cv4pve-autosnap/issues/119))
+
+### Changed
+- Updated NuGet packages to 9.1.15
+
 ## [2.1.0] - 2026-04-14
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.13" />
-    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.13" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Extension" Version="9.1.15" />
+    <PackageVersion Include="Corsinvest.ProxmoxVE.Api.Console" Version="9.1.15" />
   </ItemGroup>
 </Project>

--- a/src/Corsinvest.ProxmoxVE.AutoSnap.Api/AutoSnapEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.AutoSnap.Api/AutoSnapEngine.cs
@@ -220,9 +220,6 @@ Max % Storage :   {maxPercentageStorage}%");
             {
                 vmOut.WriteLine($"----- VM {vm.VmId} {vm.Type} {vm.Status} -----");
 
-                var resultSnapVm = new ResultSnapVm { VmId = vm.VmId };
-                lock (ret.Vms) { ret.Vms.Add(resultSnapVm); }
-
                 if (!vm.IsRunning && onlyRuns)
                 {
                     vmOut.WriteLine("Skip VM '--only-running' parameter used!");
@@ -237,6 +234,8 @@ Max % Storage :   {maxPercentageStorage}%");
                 }
 
                 var vmConfig = await client.GetVmConfigAsync(vm.Node, vm.VmType, vm.VmId);
+                var resultSnapVm = new ResultSnapVm { VmId = vm.VmId };
+                lock (ret.Vms) { ret.Vms.Add(resultSnapVm); }
                 resultSnapVm.Start();
 
                 //check agent enabled


### PR DESCRIPTION
## Summary

- Fix regression introduced in v2.1.0 where `snap` returned exit code 1 when the target set included template VMs or VMs skipped via `--only-running`
- Restores pre-2.1.0 behavior: skipped VMs are no longer added to the result list, so they do not influence the overall status

Fixes #119

## Test plan

- [ ] Run `snap` on a target set containing a template VM → verify exit code 0
- [ ] Run `snap --only-running` on a target set containing stopped VMs → verify exit code 0
- [ ] Run `snap` on a target set with a real snapshot failure → verify exit code 1
- [ ] Verify logs still show `Skip VM is template` / `Skip VM '--only-running' parameter used!`