### PR TITLE
Fix pool selection permission for Proxmox VE 9 (#122)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ All binaries on the [Releases page](https://github.com/Corsinvest/cv4pve-autosna
 | **VM.Audit**        | Read VM/CT configuration and status | Virtual machines |
 | **VM.Snapshot**     | Create and delete snapshots        | Virtual machines |
 | **Datastore.Audit** | Check storage capacity             | Storage systems  |
-| **Pool.Allocate**   | Access pool information            | Resource pools   |
+| **Pool.Audit** *(PVE 9+)* / **Pool.Allocate** *(PVE 8 and earlier)* | Read pool membership (needed for `--vmid=@pool-*`) | Resource pools |
+
+> **Pool selection (`--vmid=@pool-*`)** resolves the pool via `GET /pools`. On **Proxmox VE 9+** that endpoint requires the read-only **`Pool.Audit`** privilege; on **PVE 8 and earlier** it accepted **`Pool.Allocate`**. If pool targeting returns *"VMs NOT FOUND"* on PVE 9, grant `Pool.Audit` to the token/role. See the [Proxmox VE User Management docs](https://pve.proxmox.com/wiki/User_Management).
 
 </details>
 

--- a/src/Corsinvest.ProxmoxVE.AutoSnap.Api/AutoSnapEngine.cs
+++ b/src/Corsinvest.ProxmoxVE.AutoSnap.Api/AutoSnapEngine.cs
@@ -40,7 +40,7 @@ public partial class AutoSnapEngine(PveClient client, ILoggerFactory loggerFacto
     /// Permissions request
     /// </summary>
     /// <value></value>
-    public IEnumerable<string> Permissions { get; } = ["VM.Audit", "VM.Snapshot", "Datastore.Audit", "Pool.Allocate"];
+    public IEnumerable<string> Permissions { get; } = ["VM.Audit", "VM.Snapshot", "Datastore.Audit", "Pool.Audit"];
 
     private const string Prefix = "auto";
 
@@ -204,6 +204,12 @@ Max % Storage :   {maxPercentageStorage}%");
         {
             @out.WriteLine($"----- VMs with '{vmIdsOrNames}' NOT FOUND -----");
             @out.WriteLine("----- POSSIBLE PROBLEM PERMISSION 'VM.Audit' -----");
+
+            //pool selection needs Pool.Audit to read GET /pools (Pool.Allocate on PVE 8 and earlier)
+            if (vmIdsOrNames.Contains("@pool-"))
+            {
+                @out.WriteLine("----- POSSIBLE PROBLEM PERMISSION 'Pool.Audit' (PVE 9+) / 'Pool.Allocate' (PVE 8 and earlier) -----");
+            }
         }
 
         var nodes = vms.Select(a => a.Node).Distinct().ToList();


### PR DESCRIPTION
Closes #122

## Problem

Selecting VMs by pool (`--vmid=@pool-*`) resolves the pool through `GET /pools`. On **Proxmox VE 9+** that endpoint requires the read-only **`Pool.Audit`** privilege, whereas **PVE 8 and earlier** accepted **`Pool.Allocate`**.

A token/role granted only `Pool.Allocate` gets an empty result from `GET /pools` on PVE 9, so autosnap reports:

```
----- VMs with '@pool-lemmy' NOT FOUND -----
```

Reported and root-caused in #122 (PVE 9.2.3).

## Changes

- **Permissions:** replace `Pool.Allocate` with `Pool.Audit` in the declared permission set. `Pool.Audit` is read-only and works on both PVE 8 and 9; autosnap only needs to *read* pool membership.
- **Diagnostics:** when the target is a pool (`@pool-*`) and no VMs are found, print a hint pointing at `Pool.Audit` (PVE 9+) / `Pool.Allocate` (PVE 8 and earlier).
- **Docs:** update the required-permissions table in the README and add a note documenting the per-version requirement, linking the [Proxmox VE User Management docs](https://pve.proxmox.com/wiki/User_Management).

## Notes

`Pool.Audit` fully covers autosnap's needs (it only reads `/pools`), so `Pool.Allocate` is no longer requested.
